### PR TITLE
feat: introduce accounting- and termservice to composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 | EventServiceSolr        | 8983 |
 | OrganizationService     | 8082 | organization_topic      | 6742    |
 | TermregistrationService | 5173 | term_registration_topic | 5455    |
+| AccountingService       | 6900 | - (ToDo)                | 2345    |
+| TermService             | 6901 | - (ToDo)                | 2346    |
 
 
 # API Dokumentation
@@ -24,6 +26,12 @@ s. /swagger-ui/index.html
 
 ## TermregistrationService
 s. /swagger/index.html
+
+## TermService
+s. /swagger-ui
+
+## AccountingService
+s. /swagger-ui
 
 # Tipp
 Aktuell braucht das `docker-compose.yaml`-file über 1 GB um alle images zu pullen (und es fehlen noch einige). Bitte genug Zeit einplanen um alles runter zu laden.

--- a/src/accountingService/compose.yml
+++ b/src/accountingService/compose.yml
@@ -1,0 +1,31 @@
+services:
+    accountingservice:
+        image: nkn5729/accounting-service:latest
+        container_name: accounting-service
+        ports:
+            - 6900:6900
+        environment:
+            DATABASE_URL: jdbc:postgresql://accountingdb:5432/accounting_db
+            DATABASE_USERNAME: accountinguser
+            DATABASE_PASSWORD: accountingUser_pw_geheim
+            SERVICE_PORT: 6900
+        depends_on:
+            accountingdb:
+                condition: service_healthy
+            kafka:
+                condition: service_started
+
+    accountingdb:
+        image: postgres:latest
+        container_name: accountingdb
+        environment:
+            POSTGRES_DB: accounting_db
+            POSTGRES_USER: accountinguser
+            POSTGRES_PASSWORD: accountingUser_pw_geheim
+        ports:
+            - '2345:5432'
+        healthcheck:
+            test: ['CMD-SHELL', 'pg_isready -U accountinguser -d accounting_db']
+            interval: 5s
+            timeout: 5s
+            retries: 5

--- a/src/docker-compose.yaml
+++ b/src/docker-compose.yaml
@@ -2,6 +2,8 @@ include:
   - eventService/compose.yaml
   - organizationService/compose.yaml
   - termRegistrationService/compose.yml
+  - accountingService/compose.yml
+  - termService/compose.yml
 
 services:
   kafka:

--- a/src/termService/compose.yml
+++ b/src/termService/compose.yml
@@ -1,0 +1,31 @@
+services:
+    termservice:
+        image: nkn5729/term-service:latest
+        container_name: term-service
+        ports:
+            - 6901:6901
+        environment:
+            DATABASE_URL: jdbc:postgresql://termdb:5432/term_db
+            DATABASE_USERNAME: termuser
+            DATABASE_PASSWORD: termUser_pw_geheim
+            SERVICE_PORT: 6901
+        depends_on:
+            termdb:
+                condition: service_healthy
+            kafka:
+                condition: service_started
+
+    termdb:
+        image: postgres:latest
+        container_name: termdb
+        environment:
+            POSTGRES_DB: term_db
+            POSTGRES_USER: termuser
+            POSTGRES_PASSWORD: termUser_pw_geheim
+        ports:
+            - '2346:5432'
+        healthcheck:
+            test: ['CMD-SHELL', 'pg_isready -U termuser -d term_db']
+            interval: 5s
+            timeout: 5s
+            retries: 5


### PR DESCRIPTION
This PR introduces a Docker-based setup for both the TermService and AccountingService, each with their own PostgreSQL instance. Both services are now integrated into the main docker-compose.yml to enable a seamless, unified startup process.

- [x] Added compose-file for TermService
- [x] Added compose-file for AccountingService
- [x] Updated docs